### PR TITLE
Updated ondemand_cron.py to do a check for the number of hadoop jobs …

### DIFF
--- a/espa_common/settings.py
+++ b/espa_common/settings.py
@@ -1,3 +1,6 @@
+# The maximum number of jobs Hadoop should be able to run at once.
+# This is needed so that the job tracker doesn't exceed resource limits.
+HADOOP_MAX_JOBS = 150
 
 # Specifies the buffer length for an order line in the order file
 # The Hadoop File System block size should be a multiple of this value

--- a/scheduling/ondemand_cron.py
+++ b/scheduling/ondemand_cron.py
@@ -55,6 +55,17 @@ def process_requests(args, logger_name, queue_priority, request_priority):
     # Get the logger for this task
     logger = EspaLogging.get_logger(logger_name)
 
+
+    # check the number of hadoop jobs and don't do anything if they 
+    # are over a limit
+    job_limit = 150
+    cmd = "hadoop job -list|awk '{print $1}'|grep -c job 2>/dev/null"
+    job_count = utilities.execute_cmd(cmd)
+    if int(job_count) >= int(job_limit):
+        logger.warn('Detected {0} Hadoop jobs running'.format(job_count))
+        logger.warn('No additional jobs will be run until job count is below {0}'.format(job_limit))
+        return
+
     rpcurl = os.environ.get('ESPA_XMLRPC')
     server = None
 

--- a/scheduling/ondemand_cron.py
+++ b/scheduling/ondemand_cron.py
@@ -58,7 +58,7 @@ def process_requests(args, logger_name, queue_priority, request_priority):
 
     # check the number of hadoop jobs and don't do anything if they 
     # are over a limit
-    job_limit = 150
+    job_limit = settings.HADOOP_MAX_JOBS
     cmd = "hadoop job -list|awk '{print $1}'|grep -c job 2>/dev/null"
     job_count = utilities.execute_cmd(cmd)
     if int(job_count) >= int(job_limit):


### PR DESCRIPTION
This puts a check in place to not run Hadoop jobs if the # of active jobs is greater than a configured value.