### PR TITLE
Replace gzip with pigz (parallel implementation of gzip).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## ESPA Processing Version 2.27.1 Release Notes
+## ESPA Processing Version 2.30.0 Release Notes
 
-See git tag [v2.27.1]
+See git tag [v2.30.0]
 
 ### General Information
 This project contains the code for processing a single input dataset to the final output products.  It is the controlling code for producing a product.  It does not produce science products on it's own, it calls on applications from other ESPA projects to perform that work.  Having said that, it does contain some code to perform a few things, such as, statistics generation, statistics plotting, and warping (using GDAL).
@@ -9,8 +9,7 @@ This project contains the code for processing a single input dataset to the fina
 Please see the Release Tags for notes related to past versions.
 
 - Version change for system wide versioning
-- Remove Level-1 GCP/VER metadata files, if source not ordered
-- Fix SR Band 6 statistics glob
+- Replace gzip with pigz 
 
 ## Supported Science Products
 To generate products for a science application, it must be installed on the system and the applications provided must be available on the PATH.  See the respective science projects for installation instructions and auxiliary data requirements.

--- a/processing/staging.py
+++ b/processing/staging.py
@@ -30,7 +30,7 @@ def untar_data(source_file, destination_directory):
 
     # If both source and destination are localhost we can just copy the data
     cmd = ' '.join(['tar', '--directory', destination_directory,
-                    '-xvf', source_file])
+                        '--use-compress-program=pigz', '-xvf', source_file])
 
     logger.info("Unpacking [%s] to [%s]"
                 % (source_file, destination_directory))

--- a/processing/utilities.py
+++ b/processing/utilities.py
@@ -12,6 +12,7 @@ import commands
 import random
 import resource
 from collections import defaultdict
+from subprocess import check_output, CalledProcessError, check_call
 
 
 def date_from_year_doy(year, doy):
@@ -221,21 +222,20 @@ def tar_files(tarred_full_path, file_list, gzip=False):
         Exception(message)
     """
 
-    flags = '-cf'
+    flags = ['-cf']
     target = '%s.tar' % tarred_full_path
 
     # If zipping was chosen, change the flags and the target name
     if gzip:
-        flags = '-czf'
+        flags = ['--use-compress-program=pigz', '-cf']
         target = '%s.tar.gz' % tarred_full_path
 
-    cmd = ['tar', flags, target]
+    cmd = ['tar'] + flags + [target]
     cmd.extend(file_list)
-    cmd = ' '.join(cmd)
 
     output = ''
     try:
-        output = execute_cmd(cmd)
+        output = check_output(cmd)
     except Exception:
         msg = "Error encountered tar'ing file(s): Stdout/Stderr:"
         if len(output) > 0:
@@ -259,7 +259,7 @@ def gzip_files(file_list):
     """
 
     # Force the gzip file to overwrite any previously existing attempt
-    cmd = ['gzip', '--force']
+    cmd = ['pigz', '--force']
     cmd.extend(file_list)
     cmd = ' '.join(cmd)
 


### PR DESCRIPTION
This is a set of changes from the cloud processing group to use pigz (parallel implementation of gzip) where gzip would have been used.  Note that Bill has already put pigz on the ESPA systems.  I tested the staging and packaging steps using manual SR orders in my VM, and made a small test script to test the gzip-only use.